### PR TITLE
refactor: use separate modules instead of for_each for branch_protections

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -9,14 +9,6 @@ provider "registry.terraform.io/gitlabhq/gitlab" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/null" {
-  version     = "3.2.1"
-  constraints = "3.2.1"
-  hashes = [
-    "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/time" {
   version     = "0.9.1"
   constraints = "0.9.1"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ terraform init -reconfigure -backend-config="main.s3.tfbackend"
 # clean the state (if you need to)
 terraform state rm $(terraform state list)
 # import existing repositories (if you need to)
+# full import takes around 10 minutes because of the number of resources and
+# Github's rate limiting
 ./import.sh
 # update the infrastructure
 terraform apply

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License][shield-license]][url-license]
 [![Terraform][shield-workflow-terraform]][url-workflow-terraform]
 
-This terraform module manages [shishifubing][url-owner] organization
+Terraform module managing [shishifubing][url-owner] organization
 
 </div>
 

--- a/import.sh
+++ b/import.sh
@@ -72,6 +72,7 @@ for repo in "${repos[@]}"; do
     terraform import                          \
         "$(resource_rule_wildcard "${repo}")" \
         "${repo}:*"
+    terraform import "github_branch_default.default[\"${repo}\"]" "main"
 done
 
 for repo in "${gitlab_repos[@]}"; do

--- a/import.sh
+++ b/import.sh
@@ -64,7 +64,7 @@ for repo in "${gitlab_repos[@]}"; do
     # gitlab repository names cannot start with a special character
     repo_name="${repo}"
     [[ "${repo:0:1}" == "." ]] && repo_name="dot-${repo:1}"
-    terraform import                            \
+    terraform import                               \
         "gitlab_project.repositories[\"${repo}\"]" \
         "${owner}/${repo_name}"
 done

--- a/import.sh
+++ b/import.sh
@@ -5,22 +5,6 @@ owner="${1:-shishifubing}"
 
 template_name="{{ range . }}{{ .name }} {{ end }}"
 
-function resource_repository() {
-    echo "module.repositories[\"${1}\"].github_repository.repository"
-}
-
-function resource_rule_main() {
-    echo "module.branch_protections_main[\"${1}\"].github_branch_protection.protection"
-}
-
-function resource_rule_wildcard() {
-    echo "module.branch_protections_wildcard[\"${1}\"].github_branch_protection.protection"
-}
-
-function resource_gitlab() {
-    echo "gitlab_project.repositories[\"${1}\"]"
-}
-
 repos=$(
     gh repo list "${owner}"           \
         --json "name"                 \
@@ -62,24 +46,25 @@ terraform import                                \
     "${owner}"
 
 for repo in "${repos[@]}"; do
-    terraform import                       \
-        "$(resource_repository "${repo}")" \
+    terraform import                                                    \
+        "module.repositories[\"${repo}\"].github_repository.repository" \
         "${repo}"
-
-    terraform import                      \
-        "$(resource_rule_main "${repo}")" \
+    terraform import                                                                      \
+        "module.branch_protections_main[\"${repo}\"].github_branch_protection.protection" \
         "${repo}:main"
-    terraform import                          \
-        "$(resource_rule_wildcard "${repo}")" \
+    terraform import                                                                          \
+        "module.branch_protections_wildcard[\"${repo}\"].github_branch_protection.protection" \
         "${repo}:*"
-    terraform import "github_branch_default.default[\"${repo}\"]" "main"
+    terraform import                                 \
+        "github_branch_default.default[\"${repo}\"]" \
+        "${repo}"
 done
 
 for repo in "${gitlab_repos[@]}"; do
     # gitlab repository names cannot start with a special character
     repo_name="${repo}"
     [[ "${repo:0:1}" == "." ]] && repo_name="dot-${repo:1}"
-    terraform import                   \
-        "$(resource_gitlab "${repo}")" \
+    terraform import                            \
+        "gitlab_project.repositories[\"${repo}\"]" \
         "${owner}/${repo_name}"
 done

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ module "branch_protections_main" {
   source   = "./modules/branch_protection"
 
   config = {
-    repository_id                   = each.value.repository.name
+    repository_id                   = each.value.repository.node_id
     pattern                         = "main"
     enforce_admins                  = true
     required_approving_review_count = 0
@@ -25,7 +25,7 @@ module "branch_protections_wildcard" {
   depends_on = [module.branch_protections_main]
 
   config = {
-    repository_id           = each.value.repository.name
+    repository_id           = each.value.repository.node_id
     pattern                 = "*"
     required_linear_history = true
     allows_deletions        = true

--- a/main.tf
+++ b/main.tf
@@ -9,10 +9,10 @@ module "repositories" {
 
 # branch protection rules for github repositories
 module "branch_protections" {
-  for_each = local.branch_protections
-  source   = "./modules/branch_protection"
+  count  = length(local.branch_protections)
+  source = "./modules/branch_protection"
 
-  config = each.value
+  config = local.branch_protections[count.index]
 }
 
 resource "github_branch_default" "default" {

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ module "branch_protections_main" {
   source   = "./modules/branch_protection"
 
   config = {
-    repository_id                   = each.value.name
+    repository_id                   = each.value.repository.name
     pattern                         = "main"
     enforce_admins                  = true
     required_approving_review_count = 0
@@ -25,7 +25,7 @@ module "branch_protections_wildcard" {
   depends_on = [module.branch_protections_main]
 
   config = {
-    repository_id           = each.value.name
+    repository_id           = each.value.repository.name
     pattern                 = "*"
     required_linear_history = true
     allows_deletions        = true

--- a/repositories.tf
+++ b/repositories.tf
@@ -6,39 +6,7 @@ locals {
   }
 
   # defaults for repositories
-  repositories_defaults = {
-    branch_protections = {
-      "main" = {
-        enforce_admins                  = true
-        required_approving_review_count = 0
-      }
-      "*" = {
-        required_linear_history = true
-        allows_deletions        = true
-        allows_force_pushes     = true
-      }
-    }
-  }
-
-  # create a map of branch_protections with unique keys for `for_each`
-  branch_protections = {
-    for item in local.branch_protections_list :
-    "${item.repository_id}/${item.pattern}" => item
-  }
-  # inject branch protection patterns and repository ids into all
-  # branch_protections defined in the configs
-  branch_protections_list = flatten([
-    for repository_name, repository_config in local.repositories : [
-      for branch_protection_pattern, branch_protection_config in
-      lookup(repository_config, "branch_protections", {}) : merge(
-        {
-          pattern       = branch_protection_pattern,
-          repository_id = repository_name
-        },
-        branch_protection_config
-      )
-    ]
-  ])
+  repositories_defaults = {}
 
   # dictionary of topics to reuse
   topics = {


### PR DESCRIPTION
Order of branch protection rules is important, but `for_each` is unordered

You cannot ensure the order with `count` either