### PR TITLE
refactor(repository): change merge_commit_title

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,9 +17,10 @@ module "branch_protections_main" {
     enforce_admins                  = true
     required_approving_review_count = 0
     required_status_checks = {
-      "commit-lint" = {
-        # https://github.com/apps/commit-lint
-        contexts = ["commit-lint", "commit-lint-pr"]
+      "commits" = {
+        # https://github.com/marketplace/commitcheck
+        # https://www.commitcheck.com 
+        contexts = ["CommitCheck"]
         strict   = true
       }
     }
@@ -38,10 +39,11 @@ module "branch_protections_wildcard" {
     allows_deletions        = true
     allows_force_pushes     = true
     required_status_checks = {
-      "commit-lint" = {
-        # https://github.com/apps/commit-lint
-        contexts = ["commit-lint", "commit-lint-pr"]
-        strict   = false
+      "commits" = {
+        # https://github.com/marketplace/commitcheck
+        # https://www.commitcheck.com
+        contexts = ["CommitCheck"]
+        strict   = true
       }
     }
   }

--- a/modules/repository/variables.tf
+++ b/modules/repository/variables.tf
@@ -39,8 +39,8 @@ variable "config" {
     allow_squash_merge          = optional(bool, false)
     allow_update_branch         = optional(bool, true)
     delete_branch_on_merge      = optional(bool, true)
-    merge_commit_message        = optional(string, "PR_BODY")
-    merge_commit_title          = optional(string, "PR_TITLE")
+    merge_commit_message        = optional(string, "PR_TITLE")
+    merge_commit_title          = optional(string, "MERGE_MESSAGE")
     squash_merge_commit_message = optional(string, "COMMIT_MESSAGES")
     squash_merge_commit_title   = optional(string, "COMMIT_OR_PR_TITLE")
 


### PR DESCRIPTION
It's hard to differentiate merge commits from regular commits when you set

```hcl
merge_commit_message        = optional(string, "PR_BODY")
merge_commit_title          = optional(string, "PR_TITLE")
```